### PR TITLE
Release 0.3.0

### DIFF
--- a/hashbox/exceptions.py
+++ b/hashbox/exceptions.py
@@ -1,10 +1,11 @@
 class FrozenError(Exception):
     """Raised when attempting to modify a FrozenIndex"""
 
-    pass
-
 
 class MissingIndexError(Exception):
     """Raised when querying a field we don't have an index for"""
 
-    pass
+
+class MissingAttribute(Exception):
+    """Raise this in your attribute functions to denote that the object is missing this attribute. Finds that
+    match the attribute will never return this object. Finds that exclude the attribute will."""

--- a/hashbox/frozen/frozen_attr.py
+++ b/hashbox/frozen/frozen_attr.py
@@ -3,7 +3,7 @@ import numpy as np
 from typing import Union, Callable
 from hashbox.init_helpers import sort_by_hash, group_by_val, run_length_encode
 from hashbox.constants import SIZE_THRESH
-from hashbox.frozen.utils import make_empty_array
+from hashbox.utils import make_empty_array
 from bisect import bisect_left
 from dataclasses import dataclass
 
@@ -111,3 +111,7 @@ class FrozenFieldIndex:
             return np.sort(self.objs_by_hash.get(val))
         else:
             return make_empty_array(self.dtype)
+
+    def __len__(self):
+        tot = sum(len(v) for v in self.val_to_obj_ids.values())
+        return tot + len(self.objs_by_hash.sorted_obj_ids)

--- a/hashbox/frozen/utils.py
+++ b/hashbox/frozen/utils.py
@@ -9,7 +9,3 @@ def snp_difference(left: np.ndarray, right: np.ndarray):
     keep_these = np.ones_like(left, dtype=bool)
     keep_these[indices_to_discard] = False
     return left[keep_these]
-
-
-def make_empty_array(dtype: str):
-    return np.empty(0, dtype=dtype)

--- a/hashbox/mutable/main.py
+++ b/hashbox/mutable/main.py
@@ -10,7 +10,7 @@ class HashBox:
     def __init__(
         self,
         objs: Optional[Iterable[Any]] = None,
-        on: Iterable[Union[str, Callable]] = None,
+        on: Iterable[Union[str, Callable]] = None
     ):
         if not on:
             raise ValueError("Need at least one field to index on.")

--- a/hashbox/mutable/mutable_attr.py
+++ b/hashbox/mutable/mutable_attr.py
@@ -17,7 +17,7 @@ class MutableFieldIndex:
         self,
         field: Union[Callable, str],
         obj_map: Dict[int, Any],
-        objs: Optional[Iterable[Any]] = None,
+        objs: Optional[Iterable[Any]] = None
     ):
         self.field = field
         self.obj_map = obj_map
@@ -36,7 +36,9 @@ class MutableFieldIndex:
             return Int64Set([ids])
 
     def add(self, ptr: int, obj: Any):
-        val = get_field(obj, self.field)
+        val, success = get_field(obj, self.field)
+        if not success:
+            return
         if val in self.d:
             if isinstance(self.d[val], tuple):
                 if len(self.d[val]) == TUPLE_SIZE_MAX:
@@ -55,7 +57,9 @@ class MutableFieldIndex:
         """
         Remove a single object from the index. ptr is already known to be in the index.
         """
-        val = get_field(obj, self.field)
+        val, success = get_field(obj, self.field)
+        if not success:
+            return
         obj_ids = self.d[val]
         if isinstance(obj_ids, tuple) or isinstance(obj_ids, Int64Set):
             if isinstance(obj_ids, tuple):
@@ -68,3 +72,12 @@ class MutableFieldIndex:
                     self.d[val] = tuple(self.d[val])
         else:
             del self.d[val]
+
+    def __len__(self):
+        tot = 0
+        for key, val in self.d.items():
+            if isinstance(val, tuple) or isinstance(val, Int64Set):
+                tot += len(val)
+            else:
+                tot += 1
+        return tot

--- a/hashbox/utils.py
+++ b/hashbox/utils.py
@@ -1,17 +1,28 @@
 import numpy as np
 
-from typing import List, Union, Callable, Optional, Any, Dict
-from hashbox.exceptions import MissingIndexError
+from typing import List, Union, Callable, Optional, Any, Dict, Tuple
+
+from hashbox.exceptions import MissingIndexError, MissingAttribute
 
 
-def get_field(obj, field):
+def get_field(obj: Any, field: Union[Callable, str]) -> Tuple[Any, bool]:
+    """Get the object's attribute value. Return (value, success). Unsuccessful if attribute is missing."""
     if callable(field):
-        val = field(obj)
+        try:
+            val = field(obj)
+        except MissingAttribute:
+            return None, False
     elif isinstance(obj, dict):
-        val = obj.get(field, None)
+        try:
+            val = obj[field]
+        except KeyError:
+            return None, False
     else:
-        val = getattr(obj, field, None)
-    return val
+        try:
+            val = getattr(obj, field)
+        except AttributeError:
+            return None, False
+    return val, True
 
 
 def get_attributes(cls) -> List[str]:
@@ -37,3 +48,7 @@ def validate_query(
     missing_indices = required_indices.difference(indices)
     if missing_indices:
         raise MissingIndexError
+
+
+def make_empty_array(dtype: str):
+    return np.empty(0, dtype=dtype)

--- a/test/cov.txt
+++ b/test/cov.txt
@@ -2,18 +2,19 @@
 platform linux -- Python 3.9.7, pytest-6.2.4, py-1.10.0, pluggy-0.13.1
 rootdir: /home/theo/repos
 plugins: anyio-2.2.0, cov-3.0.0
-collected 119 items
+collected 132 items
 
-test/test_basic_operations.py ........................                   [ 20%]
-test/test_container_ops.py ..............                                [ 31%]
-test/test_edge_cases.py .......................                          [ 51%]
-test/test_examples.py ....                                               [ 54%]
-test/test_exceptions.py ........                                         [ 61%]
-test/test_fancy_gets.py ........                                         [ 68%]
-test/test_hash_collisions.py ........                                    [ 74%]
-test/test_mixed_cardinality.py ............                              [ 84%]
+test/test_basic_operations.py ........................                   [ 18%]
+test/test_container_ops.py ..............                                [ 28%]
+test/test_edge_cases.py ......................                           [ 45%]
+test/test_examples.py ....                                               [ 48%]
+test/test_exceptions.py ........                                         [ 54%]
+test/test_fancy_gets.py ........                                         [ 60%]
+test/test_hash_collisions.py ........                                    [ 66%]
+test/test_missing_attribute.py ..............                            [ 77%]
+test/test_mixed_cardinality.py ............                              [ 86%]
 test/test_mutations.py ..........                                        [ 93%]
-test/test_randomized.py .                                                [ 94%]
+test/test_soak.py .                                                      [ 94%]
 test/test_stale_objects.py .......                                       [100%]
 
 ----------- coverage: platform linux, python 3.9.7-final-0 -----------
@@ -21,19 +22,19 @@ Name                              Stmts   Miss  Cover
 -----------------------------------------------------
 hashbox/__init__.py                   2      0   100%
 hashbox/constants.py                  7      0   100%
-hashbox/exceptions.py                 4      0   100%
+hashbox/exceptions.py                 3      0   100%
 hashbox/frozen/__init__.py            0      0   100%
-hashbox/frozen/frozen_attr.py        67      0   100%
-hashbox/frozen/main.py               57      0   100%
-hashbox/frozen/utils.py              10      0   100%
-hashbox/init_helpers.py              69      0   100%
+hashbox/frozen/frozen_attr.py        70      0   100%
+hashbox/frozen/main.py               60      0   100%
+hashbox/frozen/utils.py               8      0   100%
+hashbox/init_helpers.py              75      0   100%
 hashbox/mutable/__init__.py           0      0   100%
 hashbox/mutable/main.py              75      0   100%
-hashbox/mutable/mutable_attr.py      43      0   100%
+hashbox/mutable/mutable_attr.py      54      0   100%
 hashbox/perf.py                       0      0   100%
-hashbox/utils.py                     25      0   100%
+hashbox/utils.py                     36      0   100%
 -----------------------------------------------------
-TOTAL                               359      0   100%
+TOTAL                               390      0   100%
 
 
-============================= 119 passed in 5.66s ==============================
+============================= 132 passed in 5.75s ==============================

--- a/test/test_edge_cases.py
+++ b/test/test_edge_cases.py
@@ -100,13 +100,6 @@ def test_get_zero(box_class):
     assert len(f.find({_f: "d"})) == 0
 
 
-def test_add_none():
-    f = HashBox(on="s")
-    f.add(None)
-    result = f.find({"s": None})
-    assert result[0] is None
-
-
 def test_double_add():
     f = HashBox(on="s")
     x = {"s": "hello"}

--- a/test/test_exceptions.py
+++ b/test/test_exceptions.py
@@ -1,7 +1,8 @@
+import pytest
+
 from hashbox import HashBox, FrozenHashBox
 from hashbox.exceptions import MissingIndexError
 from hashbox.constants import SIZE_THRESH
-import pytest
 
 from .conftest import AssertRaises, BadHash
 
@@ -23,7 +24,7 @@ def test_no_index_mutable():
 
 
 def test_bad_query(box_class):
-    f = box_class([0], on=["a"])
+    f = box_class([{'a': 1}], on=["a"])
     with AssertRaises(TypeError):
         f.find(match=[])
     with AssertRaises(TypeError):

--- a/test/test_missing_attribute.py
+++ b/test/test_missing_attribute.py
@@ -1,0 +1,77 @@
+import pytest
+
+
+from hashbox import HashBox
+from hashbox.exceptions import MissingAttribute
+from hashbox.constants import SIZE_THRESH
+
+
+@pytest.mark.parametrize('n_items', [1, 5, SIZE_THRESH+1])
+def test_missing_function(box_class, n_items):
+    def even(obj):
+        if obj % 2:
+            raise MissingAttribute
+        return True
+    objs = range(n_items)
+    hb = box_class(objs, [even])
+    n_even = len([x for x in range(n_items) if x % 2 == 0])
+    n_odd = n_items - n_even
+    assert len(hb) == n_items
+    assert len(hb.find(match={even: True})) == n_even
+    assert len(hb.find(exclude={even: True})) == n_odd
+    for idx in hb.indices.values():
+        assert len(idx) == n_even
+
+
+missing_attr_data = [
+    {'a': 1, 'b': 2},
+    {'a': 3},
+    {'b': 4},
+    {},
+]
+
+
+def test_add_with_missing_attributes():
+    hb = HashBox([], ['a', 'b'])
+    for d in missing_attr_data:
+        hb.add(d)
+    assert len(hb) == 4
+    assert len(hb.indices['a']) == 2
+    assert len(hb.indices['b']) == 2
+    assert len(hb.find(exclude={'b': [2, 4]})) == 2
+    assert len(hb.find(exclude={'a': [1, 3]})) == 2
+
+
+def test_remove_with_missing_attributes():
+    hb = HashBox(missing_attr_data, ['a', 'b'])
+    for d in missing_attr_data:
+        hb.remove(d)
+    assert len(hb) == 0
+    for idx in hb.indices.values():
+        assert len(idx) == 0
+
+
+def test_missing_attributes(box_class):
+    hb = box_class(missing_attr_data, ['a', 'b'])
+    for d in missing_attr_data:
+        assert d in hb
+    assert len(hb.indices['a']) == 2
+    assert len(hb.indices['b']) == 2
+
+
+def test_add_none():
+    f = HashBox(on="s")
+    f.add(None)
+    result = f.find({"s": None})
+    assert result == []
+
+
+def test_empty_attribute(box_class):
+    hb = box_class([None], on=["a"])
+    assert len(hb) == 1
+
+
+def test_add_empty_attribute():
+    hb = HashBox(on=["a"])
+    hb.add(None)
+    assert len(hb) == 1

--- a/test/test_soak.py
+++ b/test/test_soak.py
@@ -3,9 +3,9 @@ HashBox (mutable form) is pretty complex.
 Let's run a lengthy test to make sure all the pieces work as expected across many add / remove operations.
 """
 
+import random
 import time
 from datetime import datetime
-import random
 from hashbox import HashBox
 from hashbox.utils import get_field
 
@@ -139,27 +139,27 @@ class SoakTest:
 
     def check_equal(self):
         # check a string key
-        ls = [o for o in self.objs.values() if get_field(o, "planet") == "saturn"]
+        ls = [o for o in self.objs.values() if get_field(o, "planet")[0] == "saturn"]
         f_ls = self.f.find({"planet": "saturn"})
         assert len(ls) == len(f_ls)
         # check a functional key
-        ls = [o for o in self.objs.values() if get_field(o, planet_len) == 6]
+        ls = [o for o in self.objs.values() if get_field(o, planet_len)[0] == 6]
         f_ls = self.f.find({planet_len: 6})
         assert len(ls) == len(f_ls)
         # check a null-ish key
-        ls = [o for o in self.objs.values() if get_field(o, "sometimes") is None]
-        f_ls = self.f.find({"sometimes": None})
+        ls = [o for o in self.objs.values() if get_field(o, "sometimes")[1] == False]
+        f_ls = self.f.find(exclude={"sometimes": True})
         assert len(ls) == len(f_ls)
         # check a colliding key
         c = Collider()
-        ls = [o for o in self.objs.values() if get_field(o, "collider") == c]
+        ls = [o for o in self.objs.values() if get_field(o, "collider")[0] == c]
         f_ls = self.f.find({"collider": c})
         assert len(ls) == len(f_ls)
         # check an object-ish key
         t = self.random_obj()
         if t is not None:
             target_ts = get_field(t, "ts_sec")
-            ls = [o for o in self.objs.values() if get_field(o, "ts_sec") == target_ts]
+            ls = [o for o in self.objs.values() if get_field(o, "ts_sec")[0] == target_ts]
             f_ls = self.f.find({"ts_sec": target_ts})
             assert len(ls) == len(f_ls)
 


### PR DESCRIPTION
Prior to this release, missing attributes were assigned a value of `None`.

"Seems like an awful waste of space."
--Carl Sagan

From this release forward, objects with missing attributes are not added to an index. 
This greatly improves performance and memory efficiency on sparse problems.

As an example, consider making a HashBox of letter-at-position for every English word. The overwhelming majority of words will not have any letter at position 30, but some will. Now HashBox handles those appropriately.